### PR TITLE
Improve DX repository setup

### DIFF
--- a/src/container.js
+++ b/src/container.js
@@ -27,7 +27,7 @@ container
     response: asFunction(response).singleton(),
     date: asFunction(date).singleton(),
     config: asValue(config),
-    repository: asFunction(repository),
+    repository: asFunction(repository)
   })
 
 module.exports = container

--- a/src/container.js
+++ b/src/container.js
@@ -10,6 +10,7 @@ const database = require('./infra/database')
 const jwt = require('./infra/jwt')
 const response = require('./infra/support/response')
 const date = require('./infra/support/date')
+const repository = require('./infra/repositories')
 
 const container = createContainer()
 
@@ -25,7 +26,8 @@ container
     jwt: asFunction(jwt).singleton(),
     response: asFunction(response).singleton(),
     date: asFunction(date).singleton(),
-    config: asValue(config)
+    config: asValue(config),
+    repository: asFunction(repository),
   })
 
 module.exports = container

--- a/src/infra/repositories/index.js
+++ b/src/infra/repositories/index.js
@@ -1,0 +1,8 @@
+const UserRepository = require('./user')
+
+module.exports = ({ database }) => {
+  const userModel = database.models.users
+  return {
+    userRepository: UserRepository({ model: userModel })
+  }
+}

--- a/src/infra/repositories/user/index.js
+++ b/src/infra/repositories/user/index.js
@@ -1,7 +1,7 @@
 const { toEntity } = require('./transform')
 const { comparePassword } = require('../../encryption')
 
-module.exports = (model) => {
+module.exports = ({ model }) => {
   const getAll = (...args) =>
     model.findAll(...args).then((entity) =>
       entity.map((data) => {

--- a/src/interfaces/http/modules/user/index.js
+++ b/src/interfaces/http/modules/user/index.js
@@ -1,23 +1,16 @@
 const { Router } = require('express')
 const Status = require('http-status')
 const container = require('src/container') // we have to get the DI
-const userRepository = require('src/infra/repositories/user')
 const { get, post, put, remove } = require('src/app/user')
-const { compose } = require('ramda')
 
 module.exports = () => {
   const router = Router()
-  const { database, logger, response: { Success, Fail } } = container.cradle
+  const { repository: { userRepository }, logger, response: { Success, Fail } } = container.cradle
 
-  const userModel = database.models.users
-  const userUseCase = compose(
-    userRepository
-  )(userModel)
-
-  const getUseCase = get({ userRepository: userUseCase })
-  const postUseCase = post({ userRepository: userUseCase })
-  const putUseCase = put({ userRepository: userUseCase })
-  const deleteUseCase = remove({ userRepository: userUseCase })
+  const getUseCase = get({ userRepository })
+  const postUseCase = post({ userRepository })
+  const putUseCase = put({ userRepository })
+  const deleteUseCase = remove({ userRepository })
 
   /**
  * @swagger

--- a/test/api/users/delete_users.spec.js
+++ b/test/api/users/delete_users.spec.js
@@ -1,15 +1,10 @@
 /* eslint-env mocha */
-const { compose } = require('ramda')
-const { models, repository } = require('test/factory')
-const userRepository = require('src/infra/repositories/user')
+const { models } = require('test/factory')
 
 describe('Routes: DELETE Users', () => {
   const BASE_URI = `/api/${config.version}`
 
-  const UserUseCase = compose(
-    repository(userRepository),
-    models
-  )('users')
+  const UserUseCase = models('users')
 
   const signIn = app.resolve('jwt').signin()
   let token

--- a/test/api/users/get_users.spec.js
+++ b/test/api/users/get_users.spec.js
@@ -1,15 +1,10 @@
 /* eslint-env mocha */
-const { compose } = require('ramda')
-const { models, repository } = require('test/factory')
-const userRepository = require('src/infra/repositories/user')
+const { models } = require('test/factory')
 
 describe('Routes: GET Users', () => {
   const BASE_URI = `/api/${config.version}`
 
-  const UserUseCase = compose(
-    repository(userRepository),
-    models
-  )('users')
+  const UserUseCase = models('users')
 
   const signIn = app.resolve('jwt').signin()
   let token

--- a/test/api/users/post_users.spec.js
+++ b/test/api/users/post_users.spec.js
@@ -1,15 +1,11 @@
 /* eslint-env mocha */
-const { compose } = require('ramda')
-const { models, repository } = require('test/factory')
-const userRepository = require('src/infra/repositories/user')
+
+const { models } = require('test/factory')
 
 describe('Routes: POST Users', () => {
   const BASE_URI = `/api/${config.version}`
 
-  const UserUseCase = compose(
-    repository(userRepository),
-    models
-  )('users')
+  const UserUseCase = models('users')
 
   const signIn = app.resolve('jwt').signin()
   let token

--- a/test/api/users/put_users.spec.js
+++ b/test/api/users/put_users.spec.js
@@ -1,15 +1,10 @@
 /* eslint-env mocha */
-const { compose } = require('ramda')
-const { models, repository } = require('test/factory')
-const userRepository = require('src/infra/repositories/user')
+const { models } = require('test/factory')
 
 describe('Routes: PUT Users', () => {
   const BASE_URI = `/api/${config.version}`
 
-  const UserUseCase = compose(
-    repository(userRepository),
-    models
-  )('users')
+  const UserUseCase = models('users')
 
   const signIn = app.resolve('jwt').signin()
   let token


### PR DESCRIPTION
Instead of setting up **repository** per interface we make it available thru our DI, it's better for DX since we don't have to set it up every-time we want to use it.