### PR TITLE
Update Sequelize

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
     "pg": "7.8.1",
     "pm2": "3.3.1",
     "ramda": "0.26.1",
-    "sequelize": "4.43.0",
+    "sequelize": "5.5.0",
     "swagger-jsdoc": "3.2.7",
     "tcomb": "3.2.29",
     "winston": "3.2.1"

--- a/src/infra/repositories/application/index.js
+++ b/src/infra/repositories/application/index.js
@@ -21,7 +21,7 @@ module.exports = ({ model }) => {
       .catch((error) => { throw new Error(error) })
 
   const findById = (...args) =>
-    model.findById(...args)
+    model.findByPk(...args)
       .then(({ dataValues }) => toEntity(dataValues))
       .catch((error) => { throw new Error(error) })
 

--- a/src/infra/repositories/company/index.js
+++ b/src/infra/repositories/company/index.js
@@ -21,7 +21,7 @@ module.exports = ({ model }) => {
       .catch((error) => { throw new Error(error) })
 
   const findById = (...args) =>
-    model.findById(...args)
+    model.findByPk(...args)
       .then(({ dataValues }) => toEntity(dataValues))
       .catch((error) => { throw new Error(error) })
 

--- a/src/infra/repositories/listing/index.js
+++ b/src/infra/repositories/listing/index.js
@@ -21,7 +21,7 @@ module.exports = ({ model }) => {
       .catch((error) => { throw new Error(error) })
 
   const findById = (...args) =>
-    model.findById(...args)
+    model.findByPk(...args)
       .then(({ dataValues }) => toEntity(dataValues))
       .catch((error) => { throw new Error(error) })
 

--- a/src/infra/repositories/user/index.js
+++ b/src/infra/repositories/user/index.js
@@ -60,7 +60,7 @@ module.exports = ({ model }) => {
       .catch((error) => { throw new Error(error) })
 
   const findById = (...args) =>
-    model.findById(...args)
+    model.findByPk(...args)
       .then(({ dataValues }) => toEntity(dataValues))
       .catch((error) => { throw new Error(error) })
 


### PR DESCRIPTION
This PR should remove the warning about **insecure dependency**. 

- Upgraded `sequelize@5.5.0` as recommended version. 
- Fix **Breaking change** to repositories.